### PR TITLE
Refactors questions views to use DRF async views

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = []
 
 [dependency-groups]
 add-ons = [
+    "adrf>=0.1.9",
     "django-cors-headers>=4.6.0",
     "django-extensions>=4.1",
     "django-json-widget>=2.0.1",

--- a/src/config/django/base.py
+++ b/src/config/django/base.py
@@ -47,6 +47,7 @@ EXTERNAL_APPS = [
     "django_extensions",
     "oauth2_provider",
     "knox",
+    "adrf",
     # "silk",
 ]
 

--- a/src/utils/views/base.py
+++ b/src/utils/views/base.py
@@ -1,33 +1,31 @@
-from rest_framework.generics import RetrieveAPIView, UpdateAPIView
+from typing import Any, Dict, Optional
+
+from adrf.views import APIView
 
 
-class CustomRetrieveAPIView(RetrieveAPIView):
+class CustomAPIView(APIView):
     """
-    Custom RetrieveAPIView that overrides the get_object method.
-
-    This view is designed for cases where standard object retrieval
-    logic is not needed, allowing for custom response generation without
-    relying on a database object.
+    Base API view with serializer support for both sync and async views.
     """
 
-    def get_object(self):
+    serializer_class: Optional[Any] = None
+
+    def get_serializer_class(self):
+        """Return the serializer class to use."""
+        assert self.serializer_class is not None, (
+            f"'{self.__class__.__name__}' should either include a `serializer_class` "
+            "attribute, or override the `get_serializer_class()` method."
+        )
+        return self.serializer_class
+
+    def get_serializer(self, *args, **kwargs):
+        """Return a serializer instance."""
+        serializer_class = self.get_serializer_class()
+        kwargs.setdefault("context", self.get_serializer_context())
+        return serializer_class(*args, **kwargs)
+
+    def get_serializer_context(self) -> Dict[str, Any]:
         """
-        Override the default get_object method.
-
-        Returns:
-            None: No object retrieval is performed.
+        Extra context provided to the serializer class.
         """
-        return None
-
-
-class CustomUpdateAPIView(UpdateAPIView):
-    """Custom UpdateAPIView that overrides the get_object method."""
-
-    def get_object(self):
-        """
-        Override the default get_object method.
-
-        Returns:
-            None: No object retrieval is performed.
-        """
-        return None
+        return {"request": self.request, "format": self.format_kwarg, "view": self}

--- a/uv.lock
+++ b/uv.lock
@@ -7,6 +7,20 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "adrf"
+version = "0.1.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "async-property" },
+    { name = "django" },
+    { name = "djangorestframework" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/95/965b424766d934c024125499856267a84896ed0882e22bcda30549627dd2/adrf-0.1.9.tar.gz", hash = "sha256:e2f59fd84960a564b0385d9201c55531a30c6118eb40c86c5356c077f279af23", size = 17251 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f6/76/745ce39c9d0b53a08f99ad9912c2dedabc4801b05353b835267e1dd766ac/adrf-0.1.9-py3-none-any.whl", hash = "sha256:fd6c45df908e042c91571fdcff1ea54180c871ec18659b639cf3217d67ce97d5", size = 20980 },
+]
+
+[[package]]
 name = "aiohappyeyeballs"
 version = "2.6.1"
 source = { registry = "https://pypi.org/simple" }
@@ -127,6 +141,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/4a/e7/82da0a03e7ba5141f05cce0d302e6eed121ae055e0456ca228bf693984bc/asttokens-3.0.0.tar.gz", hash = "sha256:0dcd8baa8d62b0c1d118b399b2ddba3c4aff271d0d7a9e0d4c1681c79035bbc7", size = 61978 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/25/8a/c46dcc25341b5bce5472c718902eb3d38600a903b14fa6aeecef3f21a46f/asttokens-3.0.0-py3-none-any.whl", hash = "sha256:e3078351a059199dd5138cb1c706e6430c05eff2ff136af5eb4790f9d28932e2", size = 26918 },
+]
+
+[[package]]
+name = "async-property"
+version = "0.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a7/12/900eb34b3af75c11b69d6b78b74ec0fd1ba489376eceb3785f787d1a0a1d/async_property-0.2.2.tar.gz", hash = "sha256:17d9bd6ca67e27915a75d92549df64b5c7174e9dc806b30a3934dc4ff0506380", size = 16523 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/80/9f608d13b4b3afcebd1dd13baf9551c95fc424d6390e4b1cfd7b1810cd06/async_property-0.2.2-py2.py3-none-any.whl", hash = "sha256:8924d792b5843994537f8ed411165700b27b2bd966cefc4daeefc1253442a9d7", size = 9546 },
 ]
 
 [[package]]
@@ -1762,6 +1785,7 @@ source = { virtual = "." }
 
 [package.dev-dependencies]
 add-ons = [
+    { name = "adrf" },
     { name = "django-cors-headers" },
     { name = "django-extensions" },
     { name = "django-json-widget" },
@@ -1811,6 +1835,7 @@ utility = [
 
 [package.metadata.requires-dev]
 add-ons = [
+    { name = "adrf", specifier = ">=0.1.9" },
     { name = "django-cors-headers", specifier = ">=4.6.0" },
     { name = "django-extensions", specifier = ">=4.1" },
     { name = "django-json-widget", specifier = ">=2.0.1" },


### PR DESCRIPTION
Migrates question views from DRF generic views to a custom APIView implementation to enable async functionality where needed while maintaining sync compatibility.

Key changes:
- Replace CustomRetrieveAPIView/CustomUpdateAPIView inheritance with CustomAPIView
- Add adrf package for async DRF feature support (throttling, permissions, serializers)
- Convert I/O intensive views (QuestionAttemptListView, QuestionAttemptsCreateView) to async
- Keep simple views (StudentQuestionSetView) synchronous for simplicity
- Fix sync/async mixing issues that caused "HTTP handlers must be all sync or all async" errors
- Implement custom serializer methods in CustomAPIView base class

This enables asynchronous handling for performance-critical operations while maintaining familiar DRF patterns and avoiding unnecessary complexity for simple views.